### PR TITLE
Release 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "functional-programming",
     "monads",
     "typescript",
-    "oop"
+    "oop",
+    "error-handling"
   ],
   "scripts": {
     "analize": "npm run lint:fix && npm run compile",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leanmind/monads",
-  "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "version": "0.0.0-semantically-released",
   "description": "A collection of monads implemented in TypeScript using object-oriented programming.",
@@ -13,7 +13,9 @@
   ],
   "scripts": {
     "analize": "npm run lint:fix && npm run compile",
-    "build": "npm run lint:fix && tsc",
+    "build": "npm run lint:fix && npm run compile:commonjs && npm run compile:esm",
+    "compile:commonjs": "tsc --outDir dist/cjs --module commonjs",
+    "compile:esm": "tsc --outDir dist/esm --module esnext",
     "compile": "tsc --noEmit",
     "compile:watch": "npm run compile -- --watch",
     "compile:build": "tsc -b",

--- a/src/try/try.test.ts
+++ b/src/try/try.test.ts
@@ -35,7 +35,7 @@ describe('Try monad', () => {
       typeMatchable: 'None',
       tryType: 'Failure',
       matchable: Option.of<number>(undefined),
-      expected: Failure.NO_ERROR_PROVIDED,
+      expected: new Failure(new Error('No error provided')),
     },
   ])('$tryType should be created from $typeMatchable', ({ matchable, expected }) => {
     expect(Try.from(matchable)).toEqual(expected);

--- a/src/try/try.ts
+++ b/src/try/try.ts
@@ -40,7 +40,7 @@ abstract class Try<T> implements Monad<T>, Matchable<T, Error> {
   static from<T>(matchable: Matchable<T, unknown>): Try<T> {
     return matchable.match<Try<T>>(
       (value: T) => new Success(value),
-      (error: unknown) => (error instanceof Error ? new Failure(error) : Failure.NO_ERROR_PROVIDED)
+      (error: unknown) => (error instanceof Error ? new Failure(error) : new Failure(new Error('No error provided')))
     );
   }
 
@@ -135,7 +135,7 @@ class Success<T> extends Try<T> {
  * Class representing a failed computation.
  * @template T The type of the value.
  */
-class Failure<T> extends Try<T> {
+class Failure<T = Error> extends Try<T> {
   /**
    * Creates a new `Failure` instance.
    * @param {Error} error The error of the failed computation.
@@ -148,7 +148,6 @@ class Failure<T> extends Try<T> {
    * A static instance representing a failure with no error provided.
    * @type {Failure<never>}
    */
-  static NO_ERROR_PROVIDED = new Failure<never>(new Error('No error provided'));
 
   map(_: (_: never) => never): Try<never> {
     return new Failure(this.error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "declarationDir": "./dist",
     "outDir": "./dist",
     "module": "ESNext",
     "target": "ESNext",


### PR DESCRIPTION
This pull request includes several changes to the `@leanmind/monads` package, focusing on improving error handling in the `Try` monad and updating the build configuration. The most important changes include updating the `package.json` to support different module formats, modifying the `Failure` class to provide more detailed error information, and updating the tests accordingly.

### Build Configuration Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R19): Changed the `main` and `module` fields to point to CommonJS and ES module outputs respectively, and updated the build scripts to compile both module formats.

### Error Handling Improvements:

* [`src/try/try.ts`](diffhunk://#diff-2f9da71c59e3cc4a42b161c2a3b98135ed472135b8e0ee99cc7df5754fe9f8b7L43-R43): Modified the `Try.from` method to always create a new `Failure` instance with a detailed error message when no error is provided.
* [`src/try/try.ts`](diffhunk://#diff-2f9da71c59e3cc4a42b161c2a3b98135ed472135b8e0ee99cc7df5754fe9f8b7L138-R138): Updated the `Failure` class to use a default type of `Error` and removed the static `NO_ERROR_PROVIDED` instance. [[1]](diffhunk://#diff-2f9da71c59e3cc4a42b161c2a3b98135ed472135b8e0ee99cc7df5754fe9f8b7L138-R138) [[2]](diffhunk://#diff-2f9da71c59e3cc4a42b161c2a3b98135ed472135b8e0ee99cc7df5754fe9f8b7L151)

### Test Updates:

* [`src/try/try.test.ts`](diffhunk://#diff-bda42466cce6f7b217bb6f8e712e4462c9ec41e9d228e2c63cd25df6a47984bdL38-R38): Updated the test cases to reflect the changes in the `Failure` class, ensuring that a new `Failure` instance is created with a detailed error message.