### PR TITLE
feat(either): add future interoperability

### DIFF
--- a/src/future/futurizable.test.ts
+++ b/src/future/futurizable.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { Either } from '../either';
+import { Future } from './future';
+
+const testCasesFutureMapOperation = [
+  {
+    type: 'Either Right',
+    monad: Either.right(2),
+    assertion: (futureMonad: Future<number> | Future<string>, expected: Future<number> | Future<string>) => {
+      futureMonad.complete(
+        (currentValue: number | string) => {
+          expected.complete(
+            (expectedValue: number | string) => expect(currentValue).toBe(expectedValue),
+            (error) => expect(error).toBeUndefined()
+          );
+        },
+        (error) => expect(error).toBeUndefined()
+      );
+    },
+    expected: Future.of(() => Promise.resolve(2)),
+  },
+  {
+    type: 'Either Left',
+    monad: Either.left('Error'),
+    assertion: (futureMonad: Future<number> | Future<string>, expected: Future<number> | Future<string>) => {
+      futureMonad.complete(
+        (currentValue: number | string) => {
+          expected.complete(
+            (expectedValue: number | string) => expect(currentValue).toBe(expectedValue),
+            (error) => expect(error).toBeUndefined()
+          );
+        },
+        (error) => expect(error).toBeUndefined()
+      );
+    },
+    expected: Future.of(() => Promise.resolve('Error')),
+  },
+];
+
+describe('Futurizable', () => {
+  it.each(testCasesFutureMapOperation)(
+    '$type should handle toFuture correctly',
+    async ({ monad, expected, assertion }) => {
+      assertion(monad.toFuture(), expected);
+    }
+  );
+});

--- a/src/future/futurizable.ts
+++ b/src/future/futurizable.ts
@@ -1,0 +1,5 @@
+import { Future } from './future';
+
+export interface Futurizable<T> {
+  toFuture(): Future<T>;
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change will help concatenate synchronous and asynchronous calls by transforming an Either into a Future. This way, we won’t need to manually map the call; instead, by invoking the method, we make it asynchronous, allowing us to use async maps.


## Added/updated tests?

_We encourage you to keep the quality of the code by creating test._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
  have not been included_
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![capoo_working](https://media1.tenor.com/m/o35lmNBzB7kAAAAC/capoo-cat.gif)


